### PR TITLE
Update the MJ bot command version number

### DIFF
--- a/bot/src/browser-actions.ts
+++ b/bot/src/browser-actions.ts
@@ -297,7 +297,7 @@ export async function sendPromptUsingWs(
       channel_id: threadId,
       session_id: token,
       data: {
-        version: "1166847114203123795", // command version?
+        version: "1237876415471554623", // command version?
         id: "938956540159881230", // command id
         name: "imagine",
         type: 1,
@@ -305,7 +305,7 @@ export async function sendPromptUsingWs(
         application_command: {
           id: "938956540159881230", // command id
           application_id: "936929561302675456", // midjourney bot id
-          version: "1166847114203123795", // command version
+          version: "1237876415471554623", // command version
           default_member_permissions: null,
           type: 1,
           nsfw: false,


### PR DESCRIPTION
### Related Issues

#36 

### Description

Since `May 9, 2024`, the bot service has been throwing an error `400` `Unknown Integration` when trying to use the `\imagine` command in the discord server. This seemed related to a change in the command version on the discord side. This PR updates the fixed version of the command.

### Usage

Requires Docker build and push of a new image to the Docker registry. Or usage of the `docker-compose..dev.yml`